### PR TITLE
Use in2code fork of ext-oauth2-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ register it in the extension configuration:
                 'imageStorageBackendIdentifier' => '1:/user_upload/oauth',
             ],
             'secondProviderId' => [
-                'resolverClassName' => \Xima\XimaOauth2Extended\ResourceResolver\GenericResolver::class,
+                'resolverClassName' => \Xima\XimaOauth2Extended\ResourceResolver\GenericResourceResolver::class,
                 'createBackendUser' => true,
                 'createFrontendUser' => true,
                 'defaultBackendUsergroup' => '',

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": ">=8.1",
     "league/oauth2-client": ">=2.7",
-    "waldhacker/typo3-oauth2-client": ">=2.1.1 || dev-feature/v12-compatibility-1",
+    "in2code/typo3-oauth2-client-fork": ">=2.1.1 || ^3.0.0",
     "ext-pdo": "*",
     "typo3/cms-core": "^11.0 || ^12.0"
   },


### PR DESCRIPTION
Since the original repository waldhacker/ext-oauth2-client is no longer maintained, use the fork created by in2code.

See: https://github.com/waldhacker/ext-oauth2-client/issues/19#issuecomment-2018035361